### PR TITLE
Support symlinks, proper time and translate errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wiiuenv/devkitppc:20211229
+FROM wiiuenv/devkitppc:20220507
 
 WORKDIR tmp_build
 COPY . .

--- a/Dockerfile.buildlocal
+++ b/Dockerfile.buildlocal
@@ -1,3 +1,3 @@
-FROM wiiuenv/devkitppc:20211229
+FROM wiiuenv/devkitppc:20220507
 
 WORKDIR project

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Make you to have [wut](https://github.com/devkitPro/wut/) installed and use the 
 ```
 make install
 ```
+Note:
+You might have to build the latest wut from source if you use the prebuild devkitpro packages until it has a new release.
+It won't work with wut versions like wut 1.0.0-beta12 and older.
 
 ## Use this lib in Dockerfiles.
 A prebuilt version of this lib can found on dockerhub. To use it for your projects, add this to your Dockerfile.

--- a/include/iosuhax.h
+++ b/include/iosuhax.h
@@ -23,32 +23,17 @@
  ***************************************************************************/
 #pragma once
 
+#include <coreinit/filesystem.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct {
-    uint32_t flag;
-    uint32_t permission;
-    uint32_t owner_id;
-    uint32_t group_id;
-    uint32_t size;     // size in bytes
-    uint32_t physsize; // physical size on disk in bytes
-    uint32_t unk[3];
-    uint32_t id;
-    uint32_t ctime;
-    uint32_t mtime;
-    uint32_t unk2[0x0D];
-} fileStat_s;
-
-typedef struct {
-    fileStat_s stat;
-    char name[0x100];
-} directoryEntry_s;
-
-#define DIR_ENTRY_IS_DIRECTORY   0x80000000
+// Deprecated: Use FS_STAT_DIRECTORY
+#ifndef DIR_ENTRY_IS_DIRECTORY
+#define DIR_ENTRY_IS_DIRECTORY FS_STAT_FILE
+#endif
 
 #define FSA_MOUNTFLAGS_BINDMOUNT (1 << 0)
 #define FSA_MOUNTFLAGS_GLOBAL    (1 << 1)
@@ -88,7 +73,7 @@ int IOSUHAX_FSA_MakeDir(int fsaFd, const char *path, uint32_t flags);
 
 int IOSUHAX_FSA_OpenDir(int fsaFd, const char *path, int *outHandle);
 
-int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, directoryEntry_s *out_data);
+int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, FSDirectoryEntry *out_data);
 
 int IOSUHAX_FSA_RewindDir(int fsaFd, int dirHandle);
 
@@ -102,13 +87,13 @@ int IOSUHAX_FSA_ReadFile(int fsaFd, void *data, uint32_t size, uint32_t cnt, int
 
 int IOSUHAX_FSA_WriteFile(int fsaFd, const void *data, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
 
-int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, fileStat_s *out_data);
+int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, FSStat *out_data);
 
 int IOSUHAX_FSA_CloseFile(int fsaFd, int fileHandle);
 
 int IOSUHAX_FSA_SetFilePos(int fsaFd, int fileHandle, uint32_t position);
 
-int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, fileStat_s *out_data);
+int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, FSStat *out_data);
 
 int IOSUHAX_FSA_Remove(int fsaFd, const char *path);
 

--- a/source/iosuhax.c
+++ b/source/iosuhax.c
@@ -465,7 +465,7 @@ int IOSUHAX_FSA_OpenDir(int fsaFd, const char *path, int *outHandle) {
     return result_vec[0];
 }
 
-int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, directoryEntry_s *out_data) {
+int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, FSDirectoryEntry *out_data) {
     if (iosuhaxHandle < 0)
         return iosuhaxHandle;
 
@@ -480,7 +480,7 @@ int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, directoryEntry_s *out_data) {
     io_buf[0] = fsaFd;
     io_buf[1] = handle;
 
-    int result_vec_size = 4 + sizeof(directoryEntry_s);
+    int result_vec_size = 4 + sizeof(FSDirectoryEntry);
     uint8_t *result_vec = (uint8_t *) memalign(0x20, result_vec_size);
     if (!result_vec) {
         free(io_buf);
@@ -495,7 +495,7 @@ int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, directoryEntry_s *out_data) {
     }
 
     int result = *(int *) result_vec;
-    memcpy(out_data, result_vec + 4, sizeof(directoryEntry_s));
+    memcpy(out_data, result_vec + 4, sizeof(FSDirectoryEntry));
     free(io_buf);
     free(result_vec);
     return result;
@@ -688,7 +688,7 @@ int IOSUHAX_FSA_WriteFile(int fsaFd, const void *data, uint32_t size, uint32_t c
     return result;
 }
 
-int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, fileStat_s *out_data) {
+int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, FSStat *out_data) {
     if (iosuhaxHandle < 0)
         return iosuhaxHandle;
 
@@ -703,7 +703,7 @@ int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, fileStat_s *out_data) {
     io_buf[0] = fsaFd;
     io_buf[1] = fileHandle;
 
-    int out_buf_size     = 4 + sizeof(fileStat_s);
+    int out_buf_size     = 4 + sizeof(FSStat);
     uint32_t *out_buffer = (uint32_t *) memalign(0x20, out_buf_size);
     if (!out_buffer) {
         free(io_buf);
@@ -718,7 +718,7 @@ int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, fileStat_s *out_data) {
     }
 
     int result = out_buffer[0];
-    memcpy(out_data, out_buffer + 1, sizeof(fileStat_s));
+    memcpy(out_data, out_buffer + 1, sizeof(FSStat));
 
     free(io_buf);
     free(out_buffer);
@@ -780,7 +780,7 @@ int IOSUHAX_FSA_SetFilePos(int fsaFd, int fileHandle, uint32_t position) {
     return result;
 }
 
-int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, fileStat_s *out_data) {
+int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, FSStat *out_data) {
     if (iosuhaxHandle < 0)
         return iosuhaxHandle;
 
@@ -796,7 +796,7 @@ int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, fileStat_s *out_data) {
     io_buf[1] = sizeof(uint32_t) * input_cnt;
     strcpy(((char *) io_buf) + io_buf[1], path);
 
-    int out_buf_size     = 4 + sizeof(fileStat_s);
+    int out_buf_size     = 4 + sizeof(FSStat);
     uint32_t *out_buffer = (uint32_t *) memalign(0x20, out_buf_size);
     if (!out_buffer) {
         free(io_buf);
@@ -811,7 +811,7 @@ int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, fileStat_s *out_data) {
     }
 
     int result = out_buffer[0];
-    memcpy(out_data, out_buffer + 1, sizeof(fileStat_s));
+    memcpy(out_data, out_buffer + 1, sizeof(FSStat));
 
     free(io_buf);
     free(out_buffer);

--- a/source/iosuhax.c
+++ b/source/iosuhax.c
@@ -496,6 +496,12 @@ int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, FSDirectoryEntry *out_data) {
 
     int result = *(int *) result_vec;
     memcpy(out_data, result_vec + 4, sizeof(FSDirectoryEntry));
+
+    // Force FS_STAT_FILE when a size is set.
+    if ((out_data->info.flags & FS_STAT_DIRECTORY) != FS_STAT_DIRECTORY && out_data->info.size > 0) {
+        out_data->info.flags |= FS_STAT_FILE;
+    }
+
     free(io_buf);
     free(result_vec);
     return result;
@@ -720,6 +726,11 @@ int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, FSStat *out_data) {
     int result = out_buffer[0];
     memcpy(out_data, out_buffer + 1, sizeof(FSStat));
 
+    // Force FS_STAT_FILE when a size is set.
+    if ((out_data->flags & FS_STAT_DIRECTORY) != FS_STAT_DIRECTORY && out_data->size > 0) {
+        out_data->flags |= FS_STAT_FILE;
+    }
+
     free(io_buf);
     free(out_buffer);
     return result;
@@ -812,6 +823,11 @@ int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, FSStat *out_data) {
 
     int result = out_buffer[0];
     memcpy(out_data, out_buffer + 1, sizeof(FSStat));
+
+    // Force FS_STAT_FILE when a size is set.
+    if ((out_data->flags & FS_STAT_DIRECTORY) != FS_STAT_DIRECTORY && out_data->size > 0) {
+        out_data->flags |= FS_STAT_FILE;
+    }
 
     free(io_buf);
     free(out_buffer);

--- a/source/iosuhax_disc_interface.c
+++ b/source/iosuhax_disc_interface.c
@@ -143,16 +143,15 @@ static bool IOSUHAX_sdio_writeSectors(uint32_t sector, uint32_t numSectors, cons
     return true;
 }
 
-const DISC_INTERFACE IOSUHAX_sdio_disc_interface =
-        {
-                DEVICE_TYPE_WII_U_SD,
-                FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_U_SD,
-                IOSUHAX_sdio_startup,
-                IOSUHAX_sdio_isInserted,
-                IOSUHAX_sdio_readSectors,
-                IOSUHAX_sdio_writeSectors,
-                IOSUHAX_sdio_clearStatus,
-                IOSUHAX_sdio_shutdown};
+const DISC_INTERFACE IOSUHAX_sdio_disc_interface = {
+        DEVICE_TYPE_WII_U_SD,
+        FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_U_SD,
+        IOSUHAX_sdio_startup,
+        IOSUHAX_sdio_isInserted,
+        IOSUHAX_sdio_readSectors,
+        IOSUHAX_sdio_writeSectors,
+        IOSUHAX_sdio_clearStatus,
+        IOSUHAX_sdio_shutdown};
 
 static bool IOSUHAX_usb_startup(void) {
     if (!IOSUHAX_disc_io_fsa_open(FSA_REF_USB))
@@ -213,13 +212,12 @@ static bool IOSUHAX_usb_writeSectors(uint32_t sector, uint32_t numSectors, const
     return true;
 }
 
-const DISC_INTERFACE IOSUHAX_usb_disc_interface =
-        {
-                DEVICE_TYPE_WII_U_USB,
-                FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_U_USB,
-                IOSUHAX_usb_startup,
-                IOSUHAX_usb_isInserted,
-                IOSUHAX_usb_readSectors,
-                IOSUHAX_usb_writeSectors,
-                IOSUHAX_usb_clearStatus,
-                IOSUHAX_usb_shutdown};
+const DISC_INTERFACE IOSUHAX_usb_disc_interface = {
+        DEVICE_TYPE_WII_U_USB,
+        FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_U_USB,
+        IOSUHAX_usb_startup,
+        IOSUHAX_usb_isInserted,
+        IOSUHAX_usb_readSectors,
+        IOSUHAX_usb_writeSectors,
+        IOSUHAX_usb_clearStatus,
+        IOSUHAX_usb_shutdown};


### PR DESCRIPTION
It has some duplicate wut structs to extend them, so I'll probably make a pull request to add it to wut (might take a while though). But let me know if there's any issues or things I should look into.

I tried to make everything backwards compatible as much as possible while being sensible. Existing code should still compile (from what I've tested).

I had some issues deciding whether I wanted to return multiple file modes, but it's not really clear whether it's really supported in posix and due to there also being a conversion to DT_REG/DT_DIR etc for directory entries it's probably just better to have no mixing. Also better for compatibility reasons since existing code probably doesn't use bit operators to check them.

Credits to @koolkdev for figuring out the FSStat flags and structs.