### PR TITLE
Add full devoptab functionality and add extended libiosuhax functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TOPDIR ?= $(CURDIR)
 include $(DEVKITPRO)/wut/share/wut_rules
 
 export VER_MAJOR	:=	1
-export VER_MINOR	:=	1
+export VER_MINOR	:=	2
 export VER_PATCH	:=	0
 
 VERSION	:=	$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)

--- a/include/iosuhax.h
+++ b/include/iosuhax.h
@@ -35,8 +35,32 @@ extern "C" {
 #define DIR_ENTRY_IS_DIRECTORY FS_STAT_FILE
 #endif
 
-#define FSA_MOUNTFLAGS_BINDMOUNT (1 << 0)
-#define FSA_MOUNTFLAGS_GLOBAL    (1 << 1)
+// Flags for IOSUHAX_FSA_Mount
+#define FSA_MOUNTFLAGS_NONE          (0 << 0)
+#define FSA_MOUNTFLAGS_BINDMOUNT     (1 << 0)
+#define FSA_MOUNTFLAGS_GLOBAL        (1 << 1)
+
+// Flags for IOSUHAX_FSA_OpenFileEx
+#define FSA_OPENFLAGS_NONE           (0 << 0)
+#define FSA_OPENFLAGS_OPEN_ENCRYPTED (1 << 0)
+#define FSA_OPENFLAGS_PREALLOC_SPACE (1 << 1)
+
+// Flags for devoptab's "open" function that'll be converted to the above flags
+#define O_OPEN_ENCRYPTED             0x4000000
+
+typedef struct {
+    uint8_t unknown[0x1E];
+} FSFileSystemInfo;
+
+typedef struct {
+    uint8_t unknown[0x28];
+} FSDeviceInfo;
+
+typedef struct {
+    uint64_t blocks_count;
+    uint64_t some_count;
+    uint32_t block_size;
+} FSBlockInfo;
 
 int IOSUHAX_Open(const char *dev); // if dev == NULL the default path /dev/iosuhax will be used
 int IOSUHAX_Close(void);
@@ -44,67 +68,71 @@ int IOSUHAX_Close(void);
 int IOSUHAX_memwrite(uint32_t address, const uint8_t *buffer, uint32_t size); // IOSU external input
 int IOSUHAX_memread(uint32_t address, uint8_t *out_buffer, uint32_t size);    // IOSU external output
 int IOSUHAX_memcpy(uint32_t dst, uint32_t src, uint32_t size);                // IOSU internal memcpy only
-
 int IOSUHAX_kern_write32(uint32_t address, uint32_t value);
-
 int IOSUHAX_kern_read32(uint32_t address, uint32_t *out_buffer, uint32_t count);
 
 int IOSUHAX_read_otp(uint8_t *out_buffer, uint32_t size);
-
 int IOSUHAX_read_seeprom(uint8_t *out_buffer, uint32_t offset, uint32_t size);
-
 int IOSUHAX_ODM_GetDiscKey(uint8_t *discKey);
-
 int IOSUHAX_SVC(uint32_t svc_id, uint32_t *args, uint32_t arg_cnt);
 
 int IOSUHAX_FSA_Open();
-
 int IOSUHAX_FSA_Close(int fsaFd);
-
 int IOSUHAX_FSA_Mount(int fsaFd, const char *device_path, const char *volume_path, uint32_t flags, const char *arg_string, int arg_string_len);
-
 int IOSUHAX_FSA_Unmount(int fsaFd, const char *path, uint32_t flags);
-
 int IOSUHAX_FSA_FlushVolume(int fsaFd, const char *volume_path);
+int IOSUHAX_FSA_RollbackVolume(int fsaFd, const char *volume_path);
 
-int IOSUHAX_FSA_GetDeviceInfo(int fsaFd, const char *device_path, int type, uint32_t *out_data);
+// The FSA_GetDeviceInfo function was mislabeled and is now split into multiple functions
+int IOSUHAX_FSA_GetDeviceInfo(int fsaFd, const char *device_path, FSDeviceInfo *out_data);
+int IOSUHAX_FSA_GetFreeSpaceSize(int fsaFd, const char *path, uint64_t *out_data);
+int IOSUHAX_FSA_GetDirSize(int fsaFd, const char *path, uint64_t *out_data);
+int IOSUHAX_FSA_GetEntryNum(int fsaFd, const char *path, uint32_t *out_data);
+int IOSUHAX_FSA_GetFileSystemInfo(int fsaFd, const char *path, FSFileSystemInfo *out_data);
+int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, FSStat *out_data);
+int IOSUHAX_FSA_GetBadBlockInfo(int fsaFd, const char *path, FSBlockInfo *out_data);
+int IOSUHAX_FSA_GetJournalFreeSpaceSize(int fsaFd, const char *path, uint64_t *out_data);
+int IOSUHAX_FSA_GetFragmentBlockInfo(int fsaFd, const char *path, FSBlockInfo *out_data);
 
 int IOSUHAX_FSA_MakeDir(int fsaFd, const char *path, uint32_t flags);
-
 int IOSUHAX_FSA_OpenDir(int fsaFd, const char *path, int *outHandle);
-
 int IOSUHAX_FSA_ReadDir(int fsaFd, int handle, FSDirectoryEntry *out_data);
-
 int IOSUHAX_FSA_RewindDir(int fsaFd, int dirHandle);
-
 int IOSUHAX_FSA_CloseDir(int fsaFd, int handle);
-
 int IOSUHAX_FSA_ChangeDir(int fsaFd, const char *path);
+int IOSUHAX_FSA_GetCwd(int fd, char *out_data, int output_size);
+
+int IOSUHAX_FSA_MakeQuota(int fsaFd, const char *quota_path, uint32_t flags, uint64_t size);
+int IOSUHAX_FSA_FlushQuota(int fsaFd, const char *quota_path);
+int IOSUHAX_FSA_RollbackQuota(int fsaFd, const char *quota_path);
+int IOSUHAX_FSA_RollbackQuotaForce(int fsaFd, const char *quota_path);
 
 int IOSUHAX_FSA_OpenFile(int fsaFd, const char *path, const char *mode, int *outHandle);
-
+int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *outHandle, uint32_t flags, int create_mode, uint32_t create_alloc_size);
 int IOSUHAX_FSA_ReadFile(int fsaFd, void *data, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
-
 int IOSUHAX_FSA_WriteFile(int fsaFd, const void *data, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
-
-int IOSUHAX_FSA_StatFile(int fsaFd, int fileHandle, FSStat *out_data);
-
+int IOSUHAX_FSA_ReadFileWithPos(int fsaFd, void *data, uint32_t size, uint32_t cnt, uint32_t pos, int fileHandle, uint32_t flags);
+int IOSUHAX_FSA_WriteFileWithPos(int fsaFd, const void *data, uint32_t size, uint32_t cnt, uint32_t pos, int fileHandle, uint32_t flags);
+int IOSUHAX_FSA_AppendFile(int fsaFd, uint32_t size, uint32_t cnt, int fileHandle);
+int IOSUHAX_FSA_AppendFileEx(int fsaFd, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
 int IOSUHAX_FSA_CloseFile(int fsaFd, int fileHandle);
 
-int IOSUHAX_FSA_SetFilePos(int fsaFd, int fileHandle, uint32_t position);
-
-int IOSUHAX_FSA_GetStat(int fsaFd, const char *path, FSStat *out_data);
+int IOSUHAX_FSA_GetStatFile(int fsaFd, int fileHandle, FSStat *out_data);
+int IOSUHAX_FSA_FlushFile(int fsaFd, int fileHandle);
+int IOSUHAX_FSA_TruncateFile(int fsaFd, int fileHandle);
+int IOSUHAX_FSA_GetPosFile(int fsaFd, int fileHandle, uint32_t *position);
+int IOSUHAX_FSA_SetPosFile(int fsaFd, int fileHandle, uint32_t position);
+int IOSUHAX_FSA_IsEof(int fsaFd, int fileHandle);
 
 int IOSUHAX_FSA_Remove(int fsaFd, const char *path);
-
+int IOSUHAX_FSA_Rename(int fsaFd, const char *old_path, const char *new_path);
 int IOSUHAX_FSA_ChangeMode(int fsaFd, const char *path, int mode);
+int IOSUHAX_FSA_ChangeModeEx(int fsaFd, const char *path, int mode, int mask);
+int IOSUHAX_FSA_ChangeOwner(int fsaFd, const char *path, uint32_t owner, uint32_t group);
 
 int IOSUHAX_FSA_RawOpen(int fsaFd, const char *device_path, int *outHandle);
-
 int IOSUHAX_FSA_RawRead(int fsaFd, void *data, uint32_t block_size, uint32_t block_cnt, uint64_t sector_offset, int device_handle);
-
 int IOSUHAX_FSA_RawWrite(int fsaFd, const void *data, uint32_t block_size, uint32_t block_cnt, uint64_t sector_offset, int device_handle);
-
 int IOSUHAX_FSA_RawClose(int fsaFd, int device_handle);
 
 #ifdef __cplusplus

--- a/include/iosuhax.h
+++ b/include/iosuhax.h
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #pragma once
 
+#include <assert.h>
 #include <coreinit/filesystem.h>
 #include <stdint.h>
 
@@ -45,22 +46,29 @@ extern "C" {
 #define FSA_OPENFLAGS_OPEN_ENCRYPTED (1 << 0)
 #define FSA_OPENFLAGS_PREALLOC_SPACE (1 << 1)
 
-// Flags for devoptab's "open" function that'll be converted to the above flags
+// Flags for posix "open" function to use OPEN_ENCRYPTED flag
 #define O_OPEN_ENCRYPTED             0x4000000
+
 
 typedef struct {
     uint8_t unknown[0x1E];
-} FSFileSystemInfo;
+} __attribute__((packed)) FSFileSystemInfo;
+static_assert(sizeof(FSFileSystemInfo) == 0x1E, "FSFileSystemInfo struct is not 0x1E bytes!");
 
 typedef struct {
-    uint8_t unknown[0x28];
-} FSDeviceInfo;
+    uint8_t unknown1[0x8];
+    uint64_t deviceSizeInSectors;
+    uint32_t deviceSectorSize;
+    uint8_t unknown2[0x14];
+} __attribute__((packed)) FSDeviceInfo;
+static_assert(sizeof(FSDeviceInfo) == 0x28, "FSDeviceInfo struct is not 0x28 bytes!");
 
 typedef struct {
     uint64_t blocks_count;
     uint64_t some_count;
     uint32_t block_size;
-} FSBlockInfo;
+} __attribute__((packed)) FSBlockInfo;
+static_assert(sizeof(FSBlockInfo) == 0x14, "FSBlockInfo struct is not 0x14 bytes!");
 
 int IOSUHAX_Open(const char *dev); // if dev == NULL the default path /dev/iosuhax will be used
 int IOSUHAX_Close(void);
@@ -108,7 +116,7 @@ int IOSUHAX_FSA_RollbackQuota(int fsaFd, const char *quota_path);
 int IOSUHAX_FSA_RollbackQuotaForce(int fsaFd, const char *quota_path);
 
 int IOSUHAX_FSA_OpenFile(int fsaFd, const char *path, const char *mode, int *outHandle);
-int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *outHandle, uint32_t flags, int create_mode, uint32_t create_alloc_size);
+int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *outHandle, uint32_t create_mode, uint32_t flags, uint32_t prealloc_size);
 int IOSUHAX_FSA_ReadFile(int fsaFd, void *data, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
 int IOSUHAX_FSA_WriteFile(int fsaFd, const void *data, uint32_t size, uint32_t cnt, int fileHandle, uint32_t flags);
 int IOSUHAX_FSA_ReadFileWithPos(int fsaFd, void *data, uint32_t size, uint32_t cnt, uint32_t pos, int fileHandle, uint32_t flags);

--- a/source/iosuhax.c
+++ b/source/iosuhax.c
@@ -1252,11 +1252,6 @@ int IOSUHAX_FSA_GetPosFile(int fsaFd, int fileHandle, uint32_t *position) {
     int result = out_buffer[0];
     *position  = out_buffer[1];
 
-    // Force FS_STAT_FILE when a size is set.
-    if ((out_data->flags & FS_STAT_DIRECTORY) != FS_STAT_DIRECTORY && out_data->size > 0) {
-        out_data->flags |= FS_STAT_FILE;
-    }
-
     free(io_buf);
     free(out_buffer);
     return result;

--- a/source/iosuhax.c
+++ b/source/iosuhax.c
@@ -858,7 +858,7 @@ int IOSUHAX_FSA_OpenFile(int fsaFd, const char *path, const char *mode, int *out
     return result_vec[0];
 }
 
-int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *outHandle, uint32_t flags, int create_mode, uint32_t create_alloc_size) {
+int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *outHandle, uint32_t create_mode, uint32_t flags, uint32_t prealloc_size) {
     if (iosuhaxHandle < 0)
         return iosuhaxHandle;
 
@@ -873,9 +873,9 @@ int IOSUHAX_FSA_OpenFileEx(int fsaFd, const char *path, const char *mode, int *o
     io_buf[0] = fsaFd;
     io_buf[1] = sizeof(uint32_t) * input_cnt;
     io_buf[2] = io_buf[1] + strlen(path) + 1;
-    io_buf[3] = flags;
-    io_buf[4] = create_mode;
-    io_buf[5] = create_alloc_size;
+    io_buf[3] = create_mode;
+    io_buf[4] = flags;
+    io_buf[5] = prealloc_size;
     strcpy(((char *) io_buf) + io_buf[1], path);
     strcpy(((char *) io_buf) + io_buf[2], mode);
 

--- a/source/iosuhax_devoptab.c
+++ b/source/iosuhax_devoptab.c
@@ -497,8 +497,9 @@ static int fs_dev_stat_r(struct _reent *r, const char *path, struct stat *st) {
 
     FSStat stats;
     int result = IOSUHAX_FSA_GetStat(dev->fsaFd, real_path, &stats);
-    free(real_path);
+
     if (result < 0) {
+        free(real_path);
         r->_errno = fs_dev_translate_error(result);
         OSUnlockMutex(dev->pMutex);
         return -1;
@@ -518,6 +519,8 @@ static int fs_dev_stat_r(struct _reent *r, const char *path, struct stat *st) {
     st->st_atime   = fs_dev_translate_time(stats.modified);
     st->st_ctime   = fs_dev_translate_time(stats.created);
     st->st_mtime   = fs_dev_translate_time(stats.modified);
+
+    free(real_path);
 
     OSUnlockMutex(dev->pMutex);
     return 0;
@@ -544,8 +547,8 @@ static int fs_dev_lstat_r(struct _reent *r, const char *path, struct stat *st) {
 
     FSStat stats;
     int result = IOSUHAX_FSA_GetStat(dev->fsaFd, real_path, &stats);
-    free(real_path);
     if (result < 0) {
+        free(real_path);
         r->_errno = fs_dev_translate_error(result);
         OSUnlockMutex(dev->pMutex);
         return -1;
@@ -565,6 +568,8 @@ static int fs_dev_lstat_r(struct _reent *r, const char *path, struct stat *st) {
     st->st_atime   = fs_dev_translate_time(stats.modified);
     st->st_ctime   = fs_dev_translate_time(stats.created);
     st->st_mtime   = fs_dev_translate_time(stats.modified);
+
+    free(real_path);
 
     OSUnlockMutex(dev->pMutex);
     return 0;


### PR DESCRIPTION
**See https://github.com/wiiu-env/MochaPayload/pull/4 for MochaPayload changes.**

This PR is split into two parts:
 - Add missing devoptab iosuhax functionality (except being able to create links):
   - rmdir_r, rename_r, fchmod_r, fsync_r, ftruncate_r.
 - Add "extended" libiosuhax functions. Read below for the full details:

**Extended iosuhax functionality**
This PR is a part of another attempt at adding a lot of nice-to-have functions to libiosuhax and the major iosuhax implementation(s), something which was originally made by @koolkdev in PRs https://github.com/dimok789/libiosuhax/pull/3 and https://github.com/FIX94/haxchi/pull/13. I'm guessing that since both were kinda stagnant they never came to fruition, but now that Tiramisu is a thing these backwards-compatible additions* (see bottom) would be good timing.

These extended functions were required for the devoptab functionality, but I decided to implement the rest of the functions that koolkdev found. I've iterated upon that PR and corrected some things, but other then that it's pretty similar.

**Breaking changes in this PR for other developers:**
 - IOSUHAX_FSA_SetFilePos is changed to IOSUHAX_FSA_SetPosFile to reflect the name of the Wii U's original function name.
 - IOSUHAX_FSA_GetDeviceInfo has been changed to IOSUHAX_FSA_GetInfo, but you can now also use various functions that'll get the various structs you would get previously. BUT, IOSUHAX_FSA_GetDeviceInfo is now the name of one of these functions since that's the DeviceInfo struct it'll get. I hope that made sense.


**Not Fully Finished**
On the libiosuhax side:
 - Should a function be added to detect the iosuhax implementation details or whether supports a function, or should developers try a function and see if it returns without an invalid argument?
 - What the best option to rename IOSUHAX_FSA_GetDeviceInfo without a lot of confusion.  

On the Tiramisu side:
 - It enables LTO, which I think might be pretty difficult to avoid without either drastically reworking it (you could do a lot more on the libiosuhax side), removing bloaty functions or find some other way to save space.
 - Improve macros or the dispatch system to be cleaner, if that's necessary. Tried to do as much compilation time magic while still abstracting it, but it can probably be improved.
 - Add CHECK_IF_IOSUHAX command back since it prevents `IOSUHAX_Open("/dev/iosuhax")` from working and only makes it work when you supply NULL. I also don't see a reason to remove it, especially since it could be extended to also return the version of the iosuhax implementation.